### PR TITLE
Augment CodeMirror instance with detachShareJsDoc()

### DIFF
--- a/share-codemirror.js
+++ b/share-codemirror.js
@@ -33,11 +33,21 @@
 
     // *** local -> remote changes
 
-    cm.on('change', function (cm, change) {
-      if (suppress) return;
+    cm.on('change', onLocalChange);
+
+    function onLocalChange(cm, change) {
+      if (ctx.suppress) return;
+      ctx.suppress = true;
       applyToShareJS(cm, change);
+      ctx.suppress = false;
       check();
-    });
+    }
+
+    cm.detachShareJsDoc = function () {
+      ctx.onRemove = null;
+      ctx.onInsert = null;
+      cm.off('change', onLocalChange);
+    }
 
     // Convert a CodeMirror change into an op understood by share.js
     function applyToShareJS(cm, change) {


### PR DESCRIPTION
In a single app context, CodeMirror instances might be attached several times to the same shared doc. This can lead to multiple share channels attached to multiple ghost instances of CodeMirror for the same file, causing an infinite loop while the editors keep appending content to the file.

This new method allows for safely disconnecting a shareJs doc from a CodeMirror instance.
